### PR TITLE
SCRUM-11 dev/check-local-env

### DIFF
--- a/ansible/default-playbook-local.yaml
+++ b/ansible/default-playbook-local.yaml
@@ -3,25 +3,29 @@
   hosts: 127.0.0.1
   connection: local
   tasks:
-    - name: Print all facts
-      debug:
-        var: go_target_directory
-    - name: Print all facts
-      debug:
-        var: second_var
-    - name: third
-      debug:
-        var: third_var
-    - name: Run a shell command and capture output
-      shell: env
-      register: shell_output
-    - name: Print shell command output
-      debug:
-        msg: "{{ shell_output.stdout.splitlines() }}"
-    - name: ansible_env
-      debug:
-        msg: "{{ ansible_facts }}"
+#    - name: Print all facts
+#      debug:
+#        var: go_target_directory
+#    - name: Print all facts
+#      debug:
+#        var: second_var
+#    - name: third
+#      debug:
+#        var: third_var
+#    - name: Run a shell command and capture output
+#      shell: env
+#      register: shell_output
+#    - name: Print shell command output
+#      debug:
+#        msg: "{{ shell_output.stdout.splitlines() }}"
+#    - name: ansible_env
+#      debug:
+#        msg: "{{ ansible_facts['en0']['ipv4'][0]['address'] if ansible_facts['en0']['macaddress'] == 'b2:71:03:3b:3f:97' }}"
+    - name: Get Default Interface ipv4
+      ansible.builtin.debug:
+        msg: "{{ get_default_ipv4 }}"
   vars:
+    get_default_ipv4: "{{ ansible_default_ipv4['address'] }}"
     go_target_directory: >-
       {%- if ansible_facts['os_family'] == "Debian" -%}
       {{ (ansible_user_dir + '/.local') }}

--- a/ansible/default-playbook-local.yaml
+++ b/ansible/default-playbook-local.yaml
@@ -18,6 +18,9 @@
     - name: Print shell command output
       debug:
         msg: "{{ shell_output.stdout.splitlines() }}"
+    - name: ansible_env
+      debug:
+        msg: "{{ ansible_facts }}"
   vars:
     go_target_directory: >-
       {%- if ansible_facts['os_family'] == "Debian" -%}

--- a/ansible/default-playbook-local.yaml
+++ b/ansible/default-playbook-local.yaml
@@ -1,0 +1,38 @@
+---
+- name: Check Ansible Functions
+  hosts: 127.0.0.1
+  connection: local
+  tasks:
+    - name: Print all facts
+      debug:
+        var: go_target_directory
+    - name: Print all facts
+      debug:
+        var: second_var
+    - name: third
+      debug:
+        var: third_var
+    - name: Run a shell command and capture output
+      shell: env
+      register: shell_output
+    - name: Print shell command output
+      debug:
+        msg: "{{ shell_output.stdout.splitlines() }}"
+  vars:
+    go_target_directory: >-
+      {%- if ansible_facts['os_family'] == "Debian" -%}
+      {{ (ansible_user_dir + '/.local') }}
+      {%- elif ansible_facts['os_family'] == "Darwin" -%}
+      {{ (ansible_user_dir + '/Library') }}
+      {%- else -%}
+      {{ ('~/program') }}
+      {% endif %}
+    second_var: |-
+      {%- if ansible_facts['os_family'] == "Debian" -%}
+      {{ (ansible_user_dir + '/.local') }}
+      {%- elif ansible_facts['os_family'] == "Darwin" -%}
+      {{ (ansible_user_dir + '/Library') }}
+      {%- else -%}
+      {{ ('~/program') }}
+      {% endif %}
+    third_var: test

--- a/ansible/default-playbook-local.yaml
+++ b/ansible/default-playbook-local.yaml
@@ -24,8 +24,19 @@
     - name: Get Default Interface ipv4
       ansible.builtin.debug:
         msg: "{{ get_default_ipv4 }}"
+    - name: Get RBP4 Interface ipv4
+      ansible.builtin.debug:
+        msg: "{{ rbp5_address }}"
   vars:
     get_default_ipv4: "{{ ansible_default_ipv4['address'] }}"
+    rbp5_address: >-
+      {%- if get_default_ipv4 | ansible.utils.ipsubnet('192.168.0.0/24') -%}
+      192.168.0.35
+      {%- elif get_default_ipv4 | ansible.utils.ipsubnet('192.168.50.0/24') -%}
+      192.168.50.59
+      {%- else -%}
+      {{ get_default_ipv4 }}
+      {%- endif -%}
     go_target_directory: >-
       {%- if ansible_facts['os_family'] == "Debian" -%}
       {{ (ansible_user_dir + '/.local') }}

--- a/ansible/default-playbook.yaml
+++ b/ansible/default-playbook.yaml
@@ -1,6 +1,6 @@
 ---
 - name: Check Ansible Functions
-  hosts: local
+  hosts: all
   tasks:
     - name: Print all facts
       debug:

--- a/ansible/inv/2 - edge.yml
+++ b/ansible/inv/2 - edge.yml
@@ -1,7 +1,7 @@
 rbp:
   hosts:
     rbp5:
-      ansible_host: 192.168.50.59
+      ansible_host: "{{ lookup('env', 'MUIRWOODS_ADDRESS') | default('192.168.50.59', true) }}"
   vars:
     ansible_user: "{{ lookup('env', 'ANSIBLE_USER') | default('', true) }}"
     ansible_become_password: "{{ lookup('env', 'ANSIBLE_BECOME_PASSWORD') | default('', true) }}"


### PR DESCRIPTION
This pull request adds a new Ansible playbook, `ansible/default-playbook-local.yaml`, designed for local testing and debugging of Ansible functions. The playbook includes tasks for printing variable values, running shell commands, and displaying system facts.

### New playbook for local testing:

* [`ansible/default-playbook-local.yaml`](diffhunk://#diff-0661b8f86b2087737631bca32d6f6f8a32af3c4ef5059a7dee794da2ed3eb43cR1-R41): Introduced a playbook that runs on the local host (`127.0.0.1`) with a local connection. It includes tasks to debug variables (`go_target_directory`, `second_var`, `third_var`), execute a shell command (`env`), and print its output, as well as display Ansible facts.

* Added conditional logic to define variables (`go_target_directory` and `second_var`) based on the operating system family (`Debian`, `Darwin`, or others).

### Issues
SCRUM-11