### PR TITLE
Write Ansible Deployment Script to enable Kubernetes clusters

### DIFF
--- a/ansible/default-playbook-local.yaml
+++ b/ansible/default-playbook-local.yaml
@@ -30,12 +30,12 @@
   vars:
     get_default_ipv4: "{{ ansible_default_ipv4['address'] }}"
     rbp5_address: >-
-      {%- if get_default_ipv4 | ansible.utils.ipsubnet('192.168.0.0/24') -%}
+      {%- if get_default_ipv4.startswith('192.168.0.') -%}
       192.168.0.35
-      {%- elif get_default_ipv4 | ansible.utils.ipsubnet('192.168.50.0/24') -%}
+      {%- elif get_default_ipv4.startswith('192.168.50.') -%}
       192.168.50.59
       {%- else -%}
-      {{ get_default_ipv4 }}
+      {{ ip_addr | default('0.0.0.0') }}
       {%- endif -%}
     go_target_directory: >-
       {%- if ansible_facts['os_family'] == "Debian" -%}

--- a/ansible/default-playbook.yaml
+++ b/ansible/default-playbook.yaml
@@ -2,15 +2,37 @@
 - name: Check Ansible Functions
   hosts: all
   tasks:
-    - name: Print all facts
+    - name: Print ansible_architecture
       debug:
-        var: go_target_directory
-    - name: Print all facts
+        var: "{{ ansible_architecture }}"
+    - name: Print ansible_distribution_release
       debug:
-        var: second_var
-    - name: third
+        var: "{{ ansible_distribution_release }}"
+    - name: Print ansible_os_family
       debug:
-        var: third_var
+        var: '{{ ansible_os_family | lower }}'
+    - name: Print ansible_facts
+      debug:
+        msg: "{{ ansible_default_ipv4['address'] | lower }}"
+    - name: Run shell commands with multi lines
+      ansible.builtin.shell: |
+        ls
+        uname -a
+#    - name: Copy ssh key to the server's user account
+#      ansible.builtin.authorized_key:
+#        user: "{{  ansible_user }}"
+#        state: present
+#        key: "{{  lookup('file', '~/.ssh/id_rsa.pub') }}"
+#        comment: "Added by Ansible automation"
+
+#    - name: Print all facts
+#      debug:
+#        var: second_var
+#    - name: third
+#      debug:
+#        var: third_var
+    - name: Create NFS shared folder on the host
+
   vars:
     go_target_directory: >-
       {%- if ansible_facts['os_family'] == "Debian" -%}

--- a/ansible/inv-keti/0 - default.yml
+++ b/ansible/inv-keti/0 - default.yml
@@ -10,8 +10,11 @@ rbp:
       ansible_host: 192.168.0.44
       ansible_user: sunjoo
     slackers:
-      ansible_host : 192.168.0.57
+      ansible_host: 192.168.0.57
       ansible_user: pi
     lombard:
       ansible_host : 192.168.0.5
       ansible_user: pi
+    muirwoods:
+      ansible_host: 192.168.0.35
+      ansible_user: sunjoo

--- a/ansible/inv-keti/0 - default.yml
+++ b/ansible/inv-keti/0 - default.yml
@@ -1,0 +1,11 @@
+nvidia:
+  hosts:
+    agxorin1:
+      ansible_host: 192.168.0.216
+      ansible_user: ubuntu
+      ansible_become_password: "{{ lookup('env', 'ANSIBLE_AGXORIN1_PASSWORD') | default('', true) }}"
+rbp:
+  hosts:
+    hawkhill:
+      ansible_host: 192.168.0.44
+      ansible_user: sunjoo

--- a/ansible/inv-keti/0 - default.yml
+++ b/ansible/inv-keti/0 - default.yml
@@ -9,3 +9,9 @@ rbp:
     hawkhill:
       ansible_host: 192.168.0.44
       ansible_user: sunjoo
+    slackers:
+      ansible_host : 192.168.0.57
+      ansible_user: pi
+    lombard:
+      ansible_host : 192.168.0.5
+      ansible_user: pi

--- a/ansible/inv-keti/1 - k8s-vm.yml
+++ b/ansible/inv-keti/1 - k8s-vm.yml
@@ -1,0 +1,16 @@
+master:
+  hosts:
+    ubuntu-2404:
+      ansible_host: 192.168.20.130
+      ansible_user: sunjoo
+      ansible_become_password: sunjoo
+workers:
+  hosts:
+    ubuntu2:
+      ansible_host: 192.168.20.132
+      ansible_user: sunjoo
+      ansible_become_password: sunjoo
+    ubuntu2204:
+      ansible_host : 192.168.20.133
+      ansible_user: sunjoo
+      ansible_become_password: sunjoo

--- a/ansible/inv-keti/1 - k8s.yml
+++ b/ansible/inv-keti/1 - k8s.yml
@@ -1,0 +1,13 @@
+master:
+  hosts:
+    muirwoods:
+      ansible_host: 192.168.0.35
+      ansible_user: sunjoo
+workers:
+  hosts:
+    slackers:
+      ansible_host: 192.168.0.57
+      ansible_user: pi
+    lombard:
+      ansible_host : 192.168.0.5
+      ansible_user: pi

--- a/ansible/inv-keti/1 - k8s.yml
+++ b/ansible/inv-keti/1 - k8s.yml
@@ -9,5 +9,5 @@ workers:
       ansible_host: 192.168.0.57
       ansible_user: pi
     lombard:
-      ansible_host : 192.168.0.5
+      ansible_host: 192.168.0.5
       ansible_user: pi

--- a/ansible/inv-keti/2 - k3s.yml
+++ b/ansible/inv-keti/2 - k3s.yml
@@ -1,0 +1,13 @@
+master:
+  hosts:
+    muirwoods:
+      ansible_host: 192.168.0.35
+      ansible_user: sunjoo
+workers:
+  hosts:
+    slackers:
+      ansible_host: 192.168.0.57
+      ansible_user: pi
+    lombard:
+      ansible_host: 192.168.0.5
+      ansible_user: pi

--- a/ansible/inv-keti/3-aws.yml
+++ b/ansible/inv-keti/3-aws.yml
@@ -1,0 +1,13 @@
+master:
+  hosts:
+    t4-on-aws:
+      ansible_host: 52.53.160.155
+      ansible_user: ubuntu
+workers:
+  hosts:
+    slackers:
+      ansible_host: 192.168.0.57
+      ansible_user: pi
+    lombard:
+      ansible_host: 192.168.0.5
+      ansible_user: pi

--- a/ansible/inv/1 - k8s-vm.yml
+++ b/ansible/inv/1 - k8s-vm.yml
@@ -1,6 +1,6 @@
 master:
   hosts:
-    ubuntu-2404:
+    k8s-master:
       ansible_host: 192.168.20.130
       ansible_user: sunjoo
       ansible_become_password: sunjoo

--- a/ansible/inv/3 - utm.yml
+++ b/ansible/inv/3 - utm.yml
@@ -1,0 +1,19 @@
+master:
+  hosts:
+    k8s-master:
+      ansible_host: 192.168.64.4
+      ansible_user: sunjoo
+      ansible_password: sunjoo
+      ansible_become_password: sunjoo
+workers:
+  hosts:
+    ubuntu-2404:
+      ansible_host: 192.168.64.5
+    ubuntu-2404-2:
+      ansible_host: 192.168.64.7
+    ubuntu-2404-3:
+      ansible_host: 192.168.64.8
+  vars:
+    ansible_user: sunjoo
+    ansible_password: sunjoo
+    ansible_become_password: sunjoo

--- a/ansible/inv/3-aws.yml
+++ b/ansible/inv/3-aws.yml
@@ -1,0 +1,18 @@
+master:
+  hosts:
+    k8s-master:
+      ansible_host: 43.200.244.31
+      ansible_user: ubuntu
+      #ansible_ssh_common_args: '-o StrictHostKeyChecking=no -i /Users/sunjoo/.ssh/all4dich-ec2key-on-n.cali.pem'
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no -i /Users/sunjoo/.ssh/all4dich-aws-key.pem'
+workers:
+  hosts:
+    k8s-worker1:
+      ansible_host: 13.125.97.28
+      ansible_user: ubuntu
+      #ansible_ssh_common_args: '-o StrictHostKeyChecking=no -i /Users/sunjoo/.ssh/all4dich-ec2key-on-n.cali.pem'
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no -i /Users/sunjoo/.ssh/all4dich-aws-key.pem'
+ #   k8s-worker2:
+ #     ansible_host: 54.193.63.43
+ #     ansible_user: ubuntu
+ #     ansible_ssh_common_args: '-o StrictHostKeyChecking=no -i  /Users/sunjoo/.ssh/all4dich-ec2key-on-n.cali.pem'

--- a/ansible/inv/3-gcp.yml
+++ b/ansible/inv/3-gcp.yml
@@ -1,0 +1,16 @@
+master:
+  hosts:
+    k8s-master:
+      ansible_host: 34.63.132.197
+      ansible_user: ubuntu
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+workers:
+  hosts:
+    k8s-worker1:
+      ansible_host: 35.193.238.34
+      ansible_user: ubuntu
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+ #   k8s-worker2:
+ #     ansible_host: 54.193.63.43
+ #     ansible_user: ubuntu
+ #     ansible_ssh_common_args: '-o StrictHostKeyChecking=no -i  /Users/sunjoo/.ssh/all4dich-ec2key-on-n.cali.pem'

--- a/ansible/inv/3-utm.yml
+++ b/ansible/inv/3-utm.yml
@@ -11,8 +11,8 @@ workers:
       ansible_host: 192.168.64.5
     ubuntu-2404-2:
       ansible_host: 192.168.64.7
-    ubuntu-2404-3:
-      ansible_host: 192.168.64.8
+#    ubuntu-2404-3:
+#      ansible_host: 192.168.64.8
   vars:
     ansible_user: sunjoo
     ansible_password: sunjoo

--- a/ansible/inv/4-with-tiburon.yml
+++ b/ansible/inv/4-with-tiburon.yml
@@ -1,0 +1,11 @@
+master:
+  hosts:
+    muirwoods-master:
+      ansible_host: 192.168.0.35
+      ansible_user: sunjoo
+#workers:
+  hosts:
+    tiburon:
+      ansible_host: 192.168.0.182
+      ansible_user: ubuntu
+      ansible_become_password: ubuntu

--- a/ansible/inv/5-test.yaml
+++ b/ansible/inv/5-test.yaml
@@ -1,0 +1,18 @@
+master:
+  hosts:
+    k8s-master:
+      ansible_host: tiburon-cloudflare
+      ansible_user: ubuntu
+      ansible_become_password: ubuntu
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+workers:
+  hosts:
+    k8s-worker1:
+      ansible_host: santarosa.sunjoo.org
+      ansible_user: ubuntu
+      ansible_become_password: ubuntu
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+ #   k8s-worker2:
+ #     ansible_host: 54.193.63.43
+ #     ansible_user: ubuntu
+ #     ansible_ssh_common_args: '-o StrictHostKeyChecking=no -i  /Users/sunjoo/.ssh/all4dich-ec2key-on-n.cali.pem'

--- a/ansible/inv/5-test2.yaml
+++ b/ansible/inv/5-test2.yaml
@@ -1,0 +1,7 @@
+master:
+  hosts:
+    k8s-worker:
+      ansible_host: santarosa
+      ansible_user: ubuntu
+      ansible_become_password: ubuntu
+      ansible_ssh_common_args: '-o StrictHostKeyChecking=no'

--- a/ansible/playbooks/0-test.yaml
+++ b/ansible/playbooks/0-test.yaml
@@ -1,0 +1,16 @@
+- name: 2. Initialize the Kubernetes master node
+  hosts: master
+  become: yes
+  vars:
+    shared_dir: /mnt/share
+  tasks:
+    - name: Create minio/mysql data directory
+      ansible.builtin.file:
+        path: "{{ shared_dir }}/k8s/{{ item }}"
+        state: directory
+        owner: nobody
+        group: nogroup
+        mode: '0777'
+      loop:
+        - mysql
+        - minio

--- a/ansible/playbooks/enable-nfs-shared.yaml
+++ b/ansible/playbooks/enable-nfs-shared.yaml
@@ -1,0 +1,33 @@
+---
+- name: Enable nfs shared folder
+  hosts: master
+  become: true
+  tasks:
+    - name: Install NFS utilities
+      ansible.builtin.package:
+        name: nfs-kernel-server
+        state: present
+
+    - name: Create shared folder
+      ansible.builtin.file:
+        path: /mnt/nfs_share
+        state: directory
+        owner: nobody
+        group: nogroup
+        mode: '0777'
+
+    - name: Ensure export entry is present
+      ansible.builtin.lineinfile:
+        path: /etc/exports
+        line: "/mnt/nfs_share 192.168.0.0/16(rw,sync,no_subtree_check,no_root_squash)"
+        create: yes
+        state: present
+
+    - name: Enable and start NFS server
+      ansible.builtin.service:
+        name: nfs-kernel-server
+        enabled: yes
+        state: restarted
+
+    - name: Export the shared folder
+      ansible.builtin.command: exportfs -ra

--- a/ansible/playbooks/files/ip-pool.yaml.j2
+++ b/ansible/playbooks/files/ip-pool.yaml.j2
@@ -1,0 +1,15 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: my-ip-pool
+  namespace: metallb-system
+spec:
+  addresses:
+    - {{  IP_RANGE }}
+
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: advert
+  namespace: metallb-system

--- a/ansible/playbooks/files/pv-nfs.yaml
+++ b/ansible/playbooks/files/pv-nfs.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: minio-pvc
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: slow
+  volumeMode: Filesystem
+  nfs:
+      path: /mnt/share/k8s/minio
+      server: 10.128.0.13
+  claimRef:
+    namespace: kubeflow
+    name: minio-pvc
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mysql-pv-claim
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: slow
+  volumeMode: Filesystem
+  nfs:
+      path: /mnt/share/k8s/mysql
+      server: 10.128.0.13
+  claimRef:
+    namespace: kubeflow
+    name: mysql-pv-claim
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: katib-mysql
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  nfs:
+    path: /mnt/share/k8s/katib-mysql
+    server: 10.128.0.13
+  volumeMode: Filesystem
+  claimRef:
+    namespace: kubeflow
+    name: katib-mysql

--- a/ansible/playbooks/files/pv-nfs.yaml.j2
+++ b/ansible/playbooks/files/pv-nfs.yaml.j2
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: minio-pvc
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: slow
+  volumeMode: Filesystem
+  nfs:
+      path: /mnt/share/k8s/minio
+      server: {{  nfs_server_ip }}
+  claimRef:
+    namespace: kubeflow
+    name: minio-pvc
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mysql-pv-claim
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: slow
+  volumeMode: Filesystem
+  nfs:
+      path: /mnt/share/k8s/mysql
+      server: {{ nfs_server_ip }}
+  claimRef:
+    namespace: kubeflow
+    name: mysql-pv-claim
+---
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: katib-mysql
+spec:
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: ""
+  nfs:
+    path: /mnt/share/k8s/katib-mysql
+    server: {{ nfs_server_ip }}
+  volumeMode: Filesystem
+  claimRef:
+    namespace: kubeflow
+    name: katib-mysql

--- a/ansible/playbooks/install_containerd.yaml
+++ b/ansible/playbooks/install_containerd.yaml
@@ -36,7 +36,8 @@
 
     - name: 4. Add the Docker APT repository
       ansible.builtin.apt_repository:
-        repo: "deb [arch={{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        repo: "deb [arch={{ 'arm64' if ansible_architecture == 'aarch64' else ('armhf' if ansible_architecture == 'armv7l' else 'amd64') }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ ansible_os_family | lower }} {{ ansible_distribution_release }} stable"
+
         state: present
         filename: docker
         update_cache: yes

--- a/ansible/playbooks/install_containerd.yaml
+++ b/ansible/playbooks/install_containerd.yaml
@@ -36,7 +36,7 @@
 
     - name: 4. Add the Docker APT repository
       ansible.builtin.apt_repository:
-        repo: "deb [arch={{ 'arm64' if ansible_architecture == 'aarch64' else ('armhf' if ansible_architecture == 'armv7l' else 'amd64') }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ ansible_os_family | lower }} {{ ansible_distribution_release }} stable"
+        repo: "deb [arch={{ 'arm64' if ansible_architecture == 'aarch64' else ('armhf' if ansible_architecture == 'armv7l' else 'amd64') }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} stable"
 
         state: present
         filename: docker

--- a/ansible/playbooks/install_containerd.yaml
+++ b/ansible/playbooks/install_containerd.yaml
@@ -9,7 +9,7 @@
 # It is idempotent and can be safely run multiple times.
 #
 - name: Install containerd from Docker's official repository
-  hosts: all
+  hosts: "{{ lookup('env','TARGET_HOST') | default('all', true) }}"
   become: yes
   tasks:
     - name: 1. Update apt cache and install prerequisite packages

--- a/ansible/playbooks/install_containerd.yaml
+++ b/ansible/playbooks/install_containerd.yaml
@@ -1,0 +1,68 @@
+---
+#
+# Ansible Playbook to Install containerd.io
+#
+# This playbook correctly sets up the official Docker APT repository
+# before installing the containerd.io package. This resolves the
+# "No package matching 'containerd.io' is available" error.
+#
+# It is idempotent and can be safely run multiple times.
+#
+- name: Install containerd from Docker's official repository
+  hosts: all
+  become: yes
+  tasks:
+    - name: 1. Update apt cache and install prerequisite packages
+      ansible.builtin.apt:
+        name:
+          - ca-certificates
+          - curl
+          - gnupg
+        state: present
+        update_cache: yes
+
+    - name: 2. Create the directory for APT keyrings
+      ansible.builtin.file:
+        path: /etc/apt/keyrings
+        state: directory
+        mode: '0755'
+
+    - name: 3. Add Docker's official GPG key
+      ansible.builtin.get_url:
+        url: https://download.docker.com/linux/ubuntu/gpg
+        dest: /etc/apt/keyrings/docker.asc
+        mode: '0644'
+        force: true # Overwrite if it exists to ensure it's up-to-date
+
+    - name: 4. Add the Docker APT repository
+      ansible.builtin.apt_repository:
+        repo: "deb [arch={{ 'arm64' if ansible_architecture == 'aarch64' else 'amd64' }} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu {{ ansible_distribution_release }} stable"
+        state: present
+        filename: docker
+        update_cache: yes
+
+    - name: 5. Install containerd.io
+      ansible.builtin.apt:
+        name:
+          - containerd.io
+          - docker-ce
+          - docker-ce-cli
+          - docker-buildx-plugin
+          - docker-compose-plugin
+        state: present
+
+    - name: 6. Ensure containerd service is started and enabled
+      ansible.builtin.systemd_service:
+        name: containerd
+        state: started
+        enabled: yes
+
+    - name: 7. Verify containerd installation
+      ansible.builtin.command: "containerd --version"
+      register: containerd_version
+      changed_when: false
+
+    - name: Display containerd version
+      ansible.builtin.debug:
+        msg: "Containerd was successfully installed. {{ containerd_version.stdout }}"
+

--- a/ansible/playbooks/install_kubeflow.yaml
+++ b/ansible/playbooks/install_kubeflow.yaml
@@ -1,0 +1,23 @@
+- name: Install Kubeflow
+  hosts: master
+  gather_facts: false
+  vars:
+    kubeflow_manifests_repo: "https://github.com/kubeflow/manifests.git"
+    kubeflow_manifests_tag: "v1.10.1" # You can change this to your desired tag
+  tasks:
+    - name: Clone Kubeflow manifests repository
+      ansible.builtin.git:
+        repo: "{{ kubeflow_manifests_repo }}"
+        dest: "{{ ansible_user_dir }}/kubeflow-manifests"
+        version: "{{ kubeflow_manifests_tag }}"
+        single_branch: true
+
+    - name: Apply Kubeflow manifests
+      ansible.builtin.command:
+        cmd: "kubectl apply -k {{ ansible_user_dir }}/kubeflow-manifests/example"
+      register: kubeflow_install_output
+      changed_when: kubeflow_install_output.rc == 0
+
+    - name: Display Kubeflow installation output
+      ansible.builtin.debug:
+        var: kubeflow_install_output.stdout_lines

--- a/ansible/playbooks/install_kubeflow.yaml
+++ b/ansible/playbooks/install_kubeflow.yaml
@@ -1,10 +1,31 @@
 - name: Install Kubeflow
   hosts: master
-  gather_facts: false
+  gather_facts: true
   vars:
     kubeflow_manifests_repo: "https://github.com/kubeflow/manifests.git"
     kubeflow_manifests_tag: "v1.10.1" # You can change this to your desired tag
   tasks:
+    - name: Remove existing pv, pvc
+      ansible.builtin.shell: |
+        kubectl delete pv,pvc --all
+
+    - name: Read and modify pv-nfs.yaml
+      ansible.builtin.template:
+        src: "{{ playbook_dir }}/files/pv-nfs.yaml.j2"
+        dest: "{{ ansible_user_dir }}/pv-nfs-modified.yaml"
+      vars:
+        nfs_server_ip: "{{ ansible_default_ipv4['address'] }}"
+
+    - name: Apply modified pv-nfs.yaml
+      ansible.builtin.command:
+        cmd: "kubectl apply -f {{ ansible_user_dir }}/pv-nfs-modified.yaml"
+      register: pv_nfs_apply_output
+      changed_when: pv_nfs_apply_output.rc == 0
+
+    - name: Display pv-nfs apply output
+      ansible.builtin.debug:
+        var: pv_nfs_apply_output.stdout_lines
+
     - name: Clone Kubeflow manifests repository
       ansible.builtin.git:
         repo: "{{ kubeflow_manifests_repo }}"
@@ -16,7 +37,7 @@
       ansible.builtin.command:
         cmd: "kubectl apply -k {{ ansible_user_dir }}/kubeflow-manifests/example"
       register: kubeflow_install_output
-      changed_when: kubeflow_install_output.rc == 0
+      failed_when: false
 
     - name: Display Kubeflow installation output
       ansible.builtin.debug:

--- a/ansible/playbooks/install_kubeflow.yaml
+++ b/ansible/playbooks/install_kubeflow.yaml
@@ -3,7 +3,7 @@
   gather_facts: true
   vars:
     kubeflow_manifests_repo: "https://github.com/kubeflow/manifests.git"
-    kubeflow_manifests_tag: "v1.10.1" # You can change this to your desired tag
+    kubeflow_manifests_tag: "v1.9.1" # You can change this to your desired tag
   tasks:
     - name: Remove existing pv, pvc
       ansible.builtin.shell: |
@@ -33,12 +33,13 @@
         version: "{{ kubeflow_manifests_tag }}"
         single_branch: true
 
-    - name: Apply Kubeflow manifests
-      ansible.builtin.command:
-        cmd: "kubectl apply -k {{ ansible_user_dir }}/kubeflow-manifests/example"
-      register: kubeflow_install_output
-      failed_when: false
-
-    - name: Display Kubeflow installation output
-      ansible.builtin.debug:
-        var: kubeflow_install_output.stdout_lines
+# while ! kustomize build example | kubectl apply -f -; do echo "Retrying to apply resources"; sleep 20; done
+#    - name: Apply Kubeflow manifests
+#      ansible.builtin.command:
+#        cmd: "kubectl apply -k {{ ansible_user_dir }}/kubeflow-manifests/example"
+#      register: kubeflow_install_output
+#      failed_when: false
+#
+#    - name: Display Kubeflow installation output
+#      ansible.builtin.debug:
+#        var: kubeflow_install_output.stdout_lines

--- a/ansible/playbooks/k3s_cluster.yaml
+++ b/ansible/playbooks/k3s_cluster.yaml
@@ -1,0 +1,130 @@
+---
+#
+# Play 1: Prepare ALL nodes for K3s
+# This play runs on both server and agent nodes. It installs necessary
+# packages and prepares the system.
+#
+- name: 1. Prepare all K3s nodes
+  hosts: master,workers
+  become: yes
+  tasks:
+    - name: Update apt package cache
+      ansible.builtin.apt:
+        update_cache: yes
+        cache_valid_time: 3600
+
+    - name: Disable swap for K3s
+      ansible.builtin.command: swapoff -a
+      when: ansible_swaptotal_mb > 0
+
+    - name: Remove swap entry from /etc/fstab
+      ansible.builtin.lineinfile:
+        path: /etc/fstab
+        regexp: '\s+swap\s+'
+        state: absent
+
+    - name: Load required kernel modules
+      ansible.builtin.modprobe:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - overlay
+        - br_netfilter
+
+    - name: Ensure required kernel modules are loaded on boot
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/k8s.conf
+        content: |
+          overlay
+          br_netfilter
+    # K3s uses its own container runtime (containerd) and doesn't require manual configuration here.
+    - name: Set required sysctl params for Kubernetes networking
+      ansible.builtin.sysctl:
+        name: "{{ item.key }}"
+        value: "{{ item.value }}"
+        sysctl_file: /etc/sysctl.d/k8s.conf
+        state: present
+        reload: yes
+      loop:
+        - { key: 'net.bridge.bridge-nf-call-iptables', value: '1' }
+        - { key: 'net.bridge.bridge-nf-call-ip6tables', value: '1' }
+        - { key: 'net.ipv4.ip_forward', value: '1' }
+
+    - name: Install prerequisite packages
+      ansible.builtin.apt:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - curl
+          - gnupg
+        state: present
+
+#
+# Play 2: Install and Configure K3s Server
+# This play runs ONLY on the server node.
+#
+- name: 2. Install and Configure K3s Server
+  hosts: master
+  become: yes
+  tasks:
+    - name: Install K3s server
+      ansible.builtin.shell: |
+        curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--disable traefik --disable servicelb --disable metrics-server --disable local-storage --cluster-cidr 10.10.0.0/16" sh -
+      args:
+        creates: /usr/local/bin/k3s
+
+    - name: Get K3s node token
+      ansible.builtin.command: cat /var/lib/rancher/k3s/server/node-token
+      register: k3s_node_token
+      changed_when: false
+
+    - name: Store K3s node token for agent nodes
+      ansible.builtin.add_host:
+        name: "k3s_node_token"
+        value: "{{ k3s_node_token.stdout }}"
+
+    - name: Create ~/.kube/  directory
+      ansible.builtin.file:
+        path: "/home/{{ ansible_user }}/.kube"
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0700'
+
+    - name: Copy K3s config to user's .kube directory
+      ansible.builtin.copy:
+        src: /etc/rancher/k3s/k3s.yaml
+        dest: "/home/{{ ansible_user }}/.kube/config"
+        remote_src: yes
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0644'
+    - name: Ensure KUBECONFIG is set for the user
+      ansible.builtin.lineinfile:
+        path: "/home/{{ ansible_user }}/.bashrc"
+        line: 'export KUBECONFIG="/home/{{ ansible_user }}/.kube/config"'
+        state: present
+        create: yes
+
+    - name: Get /var/lib/rancher/k3s/server/node-token value and store it K3S_TOKEN variable
+      ansible.builtin.command: cat /var/lib/rancher/k3s/server/node-token
+      register: k3s_token
+      changed_when: false
+
+    - name: Get master's default IPv4 address and store it K3S_MASTER_ADDRESS
+      ansible.builtin.debug:
+        msg: "{{ ansible_default_ipv4['address'] }}"
+      register: k3s_master_address
+      changed_when: false
+
+    - name: Show the command line to add a worker node to cluster
+      debug:
+        msg: "Run curl -sfL https://get.k3s.io | K3S_URL=https://{{ k3s_master_address.msg }}:6443 K3S_TOKEN={{ k3s_token.stdout }} sh -"
+
+
+#    - name: Apply Calico CNI for pod networking (K3s default is Flannel, but Calico is often preferred)
+#      ansible.builtin.command: kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/calico.yaml # Replace with your preferred CNI if not Calico
+#      environment:
+#        KUBECONFIG: "/home/{{ ansible_user }}/.kube/config"
+#      become: no # Run as the user, not root
+#      changed_when: false

--- a/ansible/playbooks/k8s_cluster.yaml
+++ b/ansible/playbooks/k8s_cluster.yaml
@@ -71,9 +71,12 @@
         mode: '0755'
 
     - name: Generate containerd config and enable SystemdCgroup
-      ansible.builtin.shell: "containerd config default > /etc/containerd/config.toml && sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml"
-      args:
-        creates: /etc/containerd/config.toml
+      ansible.builtin.shell: |
+        containerd config default | tee /etc/containerd/config.toml
+
+    - name: Enable SystemdCgroup
+      ansible.builtin.shell: |
+        sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
 
     - name: Ensure CRI plugin is enabled in containerd
       ansible.builtin.lineinfile:
@@ -117,6 +120,10 @@
         - kubelet
         - kubeadm
         - kubectl
+    - name: Set crictl's runtime endpoint to containerd
+      ansible.builtin.shell: |
+        crictl config --set runtime-endpoint=unix:///run/containerd/containerd.sock --set image-endpoint=unix:///run/containerd/containerd.sock
+
 #
 # Play 2: Initialize the Kubernetes Master Node
 # This play runs ONLY on the master node.
@@ -131,7 +138,7 @@
       failed_when: "kubeadm_reset_result.rc != 0 and 'could not find a JNI environment' not in kubeadm_reset_result.stderr"
 
     - name: Initialize the Kubernetes cluster with kubeadm
-      ansible.builtin.command: "kubeadm init --pod-network-cidr=10.10.0.0/16 --cri-socket=unix:///run/containerd/containerd.sock"
+      ansible.builtin.command: "kubeadm init --apiserver-advertise-address={{ ansible_default_ipv4['address'] }} --pod-network-cidr=10.10.0.0/16 --cri-socket=unix:///run/containerd/containerd.sock"
       register: kubeadm_init_result
 
     - name: Create .kube directory for the user

--- a/ansible/playbooks/k8s_cluster.yaml
+++ b/ansible/playbooks/k8s_cluster.yaml
@@ -75,6 +75,13 @@
       args:
         creates: /etc/containerd/config.toml
 
+    - name: Ensure CRI plugin is enabled in containerd
+      ansible.builtin.lineinfile:
+        path: /etc/containerd/config.toml
+        regexp: '^\s*disabled_plugins = \["cri"\]'
+        line: '# disabled_plugins = ["cri"]'
+        state: present
+
     - name: Restart and enable containerd service
       ansible.builtin.systemd:
         name: containerd
@@ -82,15 +89,14 @@
         enabled: yes
         daemon_reload: yes
 
-    - name: Add Google's APT signing key for Kubernetes
-      ansible.builtin.get_url:
-        url: "https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key"
-        dest: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-        mode: '0644'
+    - name: Download and add Google's APT signing key for Kubernetes
+      ansible.builtin.shell: "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg"
+      args:
+        creates: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
     - name: Add Kubernetes APT repository
       ansible.builtin.apt_repository:
-        repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /"
+        repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"
         state: present
         filename: kubernetes
 
@@ -111,7 +117,6 @@
         - kubelet
         - kubeadm
         - kubectl
-
 #
 # Play 2: Initialize the Kubernetes Master Node
 # This play runs ONLY on the master node.
@@ -126,7 +131,7 @@
       failed_when: "kubeadm_reset_result.rc != 0 and 'could not find a JNI environment' not in kubeadm_reset_result.stderr"
 
     - name: Initialize the Kubernetes cluster with kubeadm
-      ansible.builtin.command: "kubeadm init --pod-network-cidr=192.168.0.0/16 --cri-socket=unix:///var/run/containerd/containerd.sock"
+      ansible.builtin.command: "kubeadm init --pod-network-cidr=10.10.0.0/16 --cri-socket=unix:///run/containerd/containerd.sock"
       register: kubeadm_init_result
 
     - name: Create .kube directory for the user

--- a/ansible/playbooks/k8s_cluster.yaml
+++ b/ansible/playbooks/k8s_cluster.yaml
@@ -1,0 +1,182 @@
+---
+#
+# Play 1: Prepare ALL nodes for Kubernetes
+# This play runs on both master and worker nodes. It installs necessary
+# packages, configures the container runtime, and prepares the system.
+#
+- name: 1. Prepare all k8s nodes
+  hosts: all
+  become: yes
+  tasks:
+    - name: Update apt package cache
+      ansible.builtin.apt:
+        update_cache: yes
+        cache_valid_time: 3600
+
+    - name: Disable swap for Kubernetes
+      ansible.builtin.command: swapoff -a
+      when: ansible_swaptotal_mb > 0
+
+    - name: Remove swap entry from /etc/fstab
+      ansible.builtin.lineinfile:
+        path: /etc/fstab
+        regexp: '\s+swap\s+'
+        state: absent
+
+    - name: Load required kernel modules
+      ansible.builtin.modprobe:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - overlay
+        - br_netfilter
+
+    - name: Ensure required kernel modules are loaded on boot
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/k8s.conf
+        content: |
+          overlay
+          br_netfilter
+
+    - name: Set required sysctl params for Kubernetes networking
+      ansible.builtin.sysctl:
+        name: "{{ item.key }}"
+        value: "{{ item.value }}"
+        sysctl_file: /etc/sysctl.d/k8s.conf
+        state: present
+        reload: yes
+      loop:
+        - { key: 'net.bridge.bridge-nf-call-iptables', value: '1' }
+        - { key: 'net.bridge.bridge-nf-call-ip6tables', value: '1' }
+        - { key: 'net.ipv4.ip_forward', value: '1' }
+
+    - name: Install prerequisite packages
+      ansible.builtin.apt:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - curl
+          - gnupg
+        state: present
+
+    - name: Install containerd (container runtime)
+      ansible.builtin.apt:
+        name: containerd.io
+        state: present
+
+    - name: Create default containerd configuration
+      ansible.builtin.file:
+        path: /etc/containerd
+        state: directory
+        mode: '0755'
+
+    - name: Generate containerd config and enable SystemdCgroup
+      ansible.builtin.shell: "containerd config default > /etc/containerd/config.toml && sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml"
+      args:
+        creates: /etc/containerd/config.toml
+
+    - name: Restart and enable containerd service
+      ansible.builtin.systemd:
+        name: containerd
+        state: restarted
+        enabled: yes
+        daemon_reload: yes
+
+    - name: Add Google's APT signing key for Kubernetes
+      ansible.builtin.get_url:
+        url: "https://pkgs.k8s.io/core:/stable:/v1.30/deb/Release.key"
+        dest: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+        mode: '0644'
+
+    - name: Add Kubernetes APT repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.30/deb/ /"
+        state: present
+        filename: kubernetes
+
+    - name: Install Kubernetes components (kubelet, kubeadm, kubectl)
+      ansible.builtin.apt:
+        name:
+          - kubelet
+          - kubeadm
+          - kubectl
+        state: present
+        update_cache: yes
+
+    - name: Hold Kubernetes components at their current version
+      ansible.builtin.dpkg_selections:
+        name: "{{ item }}"
+        selection: hold
+      loop:
+        - kubelet
+        - kubeadm
+        - kubectl
+
+#
+# Play 2: Initialize the Kubernetes Master Node
+# This play runs ONLY on the master node.
+#
+- name: 2. Initialize the Kubernetes master node
+  hosts: master
+  become: yes
+  tasks:
+    - name: Reset existing kubeadm cluster if present
+      ansible.builtin.command: kubeadm reset -f
+      register: kubeadm_reset_result
+      failed_when: "kubeadm_reset_result.rc != 0 and 'could not find a JNI environment' not in kubeadm_reset_result.stderr"
+
+    - name: Initialize the Kubernetes cluster with kubeadm
+      ansible.builtin.command: "kubeadm init --pod-network-cidr=192.168.0.0/16 --cri-socket=unix:///var/run/containerd/containerd.sock"
+      register: kubeadm_init_result
+
+    - name: Create .kube directory for the user
+      ansible.builtin.file:
+        path: "/home/{{ ansible_user }}/.kube"
+        state: directory
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0755'
+
+    - name: Copy admin.conf to user's .kube directory
+      ansible.builtin.copy:
+        src: /etc/kubernetes/admin.conf
+        dest: "/home/{{ ansible_user }}/.kube/config"
+        remote_src: yes
+        owner: "{{ ansible_user }}"
+        group: "{{ ansible_user }}"
+        mode: '0644'
+
+    - name: Generate and register the worker join command
+      ansible.builtin.command: kubeadm token create --print-join-command
+      register: kubeadm_join_command
+      changed_when: false
+
+    - name: Store the join command for worker nodes to use
+      ansible.builtin.add_host:
+        name: "kubeadm_join_command"
+        value: "{{ kubeadm_join_command.stdout }}"
+
+    - name: Apply Calico CNI for pod networking
+      ansible.builtin.command: kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/calico.yaml
+      environment:
+        KUBECONFIG: "/home/{{ ansible_user }}/.kube/config"
+      become: no # Run as the user, not root
+      changed_when: false
+
+#
+# Play 3: Join Worker Nodes to the Cluster
+# This play runs ONLY on the worker nodes.
+#
+- name: 3. Join worker nodes to the Kubernetes cluster
+  hosts: workers
+  become: yes
+  tasks:
+    - name: Reset existing kubeadm cluster on worker
+      ansible.builtin.command: kubeadm reset -f
+      register: kubeadm_reset_result
+      failed_when: "kubeadm_reset_result.rc != 0 and 'could not find a JNI environment' not in kubeadm_reset_result.stderr"
+
+    - name: Join the worker node to the cluster
+      ansible.builtin.command: "{{ hostvars['kubeadm_join_command']['value'] }}"
+      register: worker_join_result
+      changed_when: "'This node has joined the cluster' in worker_join_result.stdout"

--- a/ansible/playbooks/k8s_cluster.yaml
+++ b/ansible/playbooks/k8s_cluster.yaml
@@ -93,13 +93,13 @@
         daemon_reload: yes
 
     - name: Download and add Google's APT signing key for Kubernetes
-      ansible.builtin.shell: "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg"
+      ansible.builtin.shell: "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg"
       args:
         creates: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
 
     - name: Add Kubernetes APT repository
       ansible.builtin.apt_repository:
-        repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /"
+        repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /"
         state: present
         filename: kubernetes
 
@@ -131,14 +131,67 @@
 - name: 2. Initialize the Kubernetes master node
   hosts: master
   become: yes
+  vars:
+    shared_dir: /mnt/share
   tasks:
+    - name: Install NFS utilities for NFS Server
+      ansible.builtin.package:
+        name: nfs-kernel-server
+        state: present
+
+    - name: Create shared directory
+      ansible.builtin.file:
+        path: "{{ shared_dir }}"
+        state: directory
+        owner: nobody
+        group: nogroup
+        mode: '0777'
+
+    - name: Create minio/mysql data directory
+      ansible.builtin.file:
+        path: "{{ shared_dir }}/k8s/{{ item }}"
+        state: directory
+        owner: nobody
+        group: nogroup
+        mode: '0777'
+      loop:
+        - mysql
+        - minio
+        - katib-mysql
+
+    - name: Ensure export entry is present
+      ansible.builtin.lineinfile:
+        path: /etc/exports
+        line: "{{ shared_dir }} *(rw,sync,no_subtree_check,no_root_squash)"
+
+        create: yes
+        state: present
+
+    - name: Enable and start NFS server
+      ansible.builtin.service:
+        name: nfs-kernel-server
+        enabled: yes
+        state: restarted
+
+    - name: Export the shared folder
+      ansible.builtin.command: exportfs -ra
+
+    - name: Download and add Helm's APT signing key
+      ansible.builtin.shell: "curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | sudo tee /usr/share/keyrings/helm.gpg > /dev/null"
+
+    - name: Install helm
+      ansible.builtin.shell: |
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+        apt-get update -y
+        apt-get install helm -y
+
     - name: Reset existing kubeadm cluster if present
       ansible.builtin.command: kubeadm reset -f
       register: kubeadm_reset_result
       failed_when: "kubeadm_reset_result.rc != 0 and 'could not find a JNI environment' not in kubeadm_reset_result.stderr"
 
     - name: Initialize the Kubernetes cluster with kubeadm
-      ansible.builtin.command: "kubeadm init --apiserver-advertise-address={{ ansible_default_ipv4['address'] }} --pod-network-cidr=10.10.0.0/16 --cri-socket=unix:///run/containerd/containerd.sock"
+      ansible.builtin.command: "kubeadm init --apiserver-advertise-address={{ ansible_default_ipv4['address'] }} --pod-network-cidr=156.147.0.0/16 --cri-socket=unix:///run/containerd/containerd.sock"
       register: kubeadm_init_result
 
     - name: Create .kube directory for the user
@@ -183,6 +236,12 @@
   hosts: workers
   become: yes
   tasks:
+    - name: Install prerequisite packages for k8s worker
+      ansible.builtin.apt:
+        name:
+          - nfs-common
+        state: present
+
     - name: Reset existing kubeadm cluster on worker
       ansible.builtin.command: kubeadm reset -f
       register: kubeadm_reset_result

--- a/ansible/playbooks/k8s_cluster.yaml
+++ b/ansible/playbooks/k8s_cluster.yaml
@@ -99,7 +99,7 @@
 
     - name: Add Kubernetes APT repository
       ansible.builtin.apt_repository:
-        repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.29/deb/ /"
+        repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /"
         state: present
         filename: kubernetes
 
@@ -158,6 +158,7 @@
         - mysql
         - minio
         - katib-mysql
+        - authservice
 
     - name: Ensure export entry is present
       ansible.builtin.lineinfile:
@@ -184,6 +185,14 @@
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/helm.gpg] https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
         apt-get update -y
         apt-get install helm -y
+
+    - name: Install Kustomize
+      ansible.builtin.shell: |
+        rm -rfv /usr/local/bin/kustomize
+        rm -rfv /tmp/install_kustomize.sh
+        curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh -o /tmp/install_kustomize.sh
+        chmod +x /tmp/install_kustomize.sh
+        /tmp/install_kustomize.sh 5.4.3 /usr/local/bin
 
     - name: Reset existing kubeadm cluster if present
       ansible.builtin.command: kubeadm reset -f
@@ -228,6 +237,10 @@
       become: no # Run as the user, not root
       changed_when: false
 
+    - name: Enable to schedule Pods on the control plane
+      ansible.builtin.shell: |
+         kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+      become: no
 #
 # Play 3: Join Worker Nodes to the Cluster
 # This play runs ONLY on the worker nodes.

--- a/ansible/playbooks/k8s_cluster.yaml
+++ b/ansible/playbooks/k8s_cluster.yaml
@@ -57,6 +57,9 @@
           - ca-certificates
           - curl
           - gnupg
+          - vim
+          - build-essential
+          - tmux
         state: present
 
     - name: Install containerd (container runtime)
@@ -91,6 +94,11 @@
         state: restarted
         enabled: yes
         daemon_reload: yes
+
+    - name: Remove old kubernetes apt repository file
+      ansible.builtin.file:
+        path: /etc/apt/sources.list.d/kubernetes.list
+        state: absent
 
     - name: Download and add Google's APT signing key for Kubernetes
       ansible.builtin.shell: "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg"
@@ -156,7 +164,7 @@
         mode: '0777'
       loop:
         - mysql
-        - minio
+        - mini
         - katib-mysql
         - authservice
 
@@ -192,7 +200,7 @@
         rm -rfv /tmp/install_kustomize.sh
         curl -s https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh -o /tmp/install_kustomize.sh
         chmod +x /tmp/install_kustomize.sh
-        /tmp/install_kustomize.sh 5.4.3 /usr/local/bin
+        /tmp/install_kustomize.sh 5.2.1 /usr/local/bin
 
     - name: Reset existing kubeadm cluster if present
       ansible.builtin.command: kubeadm reset -f
@@ -231,7 +239,7 @@
         value: "{{ kubeadm_join_command.stdout }}"
 
     - name: Apply Calico CNI for pod networking
-      ansible.builtin.command: kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.28.0/manifests/calico.yaml
+      ansible.builtin.command: kubectl apply -f https://raw.githubusercodf tent.com/projectcalico/calico/v3.28.0/manifests/calico.yaml
       environment:
         KUBECONFIG: "/home/{{ ansible_user }}/.kube/config"
       become: no # Run as the user, not root
@@ -241,7 +249,30 @@
       ansible.builtin.shell: |
          kubectl taint nodes --all node-role.kubernetes.io/control-plane-
       become: no
-#
+
+    - name: Install Metallb
+      ansible.builtin.command: kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml
+      become: no
+
+    - name: Wait for 60 seconds
+      ansible.builtin.pause:
+        seconds: 60
+
+    - name: Read and Modify IP Pool Manifest
+      ansible.builtin.template:
+        src: "{{ playbook_dir }}/files/ip-pool.yaml.j2"
+        dest: "/tmp/ip-pool-modified.yaml"
+      vars:
+        IP_RANGE: "192.168.0.240-192.168.0.250"
+      become: no
+
+    - name: Apply IP Pool Manifest
+      ansible.builtin.command:
+        cmd: "kubectl apply -f /tmp/ip-pool-modified.yaml"
+      register: ip_pool_apply_output
+      changed_when: ip_pool_apply_output.rc == 0
+      become: no
+
 # Play 3: Join Worker Nodes to the Cluster
 # This play runs ONLY on the worker nodes.
 #

--- a/ansible/playbooks/k8s_cluster_master.yaml
+++ b/ansible/playbooks/k8s_cluster_master.yaml
@@ -1,0 +1,126 @@
+---
+#
+# Play 1: Prepare ALL nodes for Kubernetes
+# This play runs on both master and worker nodes. It installs necessary
+# packages, configures the container runtime, and prepares the system.
+#
+- name: 1. Prepare all k8s nodes
+  hosts: all
+  become: yes
+  tasks:
+    - name: Update apt package cache
+      ansible.builtin.apt:
+        update_cache: yes
+        cache_valid_time: 3600
+
+    - name: Disable swap for Kubernetes
+      ansible.builtin.command: swapoff -a
+      when: ansible_swaptotal_mb > 0
+
+    - name: Remove swap entry from /etc/fstab
+      ansible.builtin.lineinfile:
+        path: /etc/fstab
+        regexp: '\s+swap\s+'
+        state: absent
+
+    - name: Load required kernel modules
+      ansible.builtin.modprobe:
+        name: "{{ item }}"
+        state: present
+      loop:
+        - overlay
+        - br_netfilter
+
+    - name: Ensure required kernel modules are loaded on boot
+      ansible.builtin.copy:
+        dest: /etc/modules-load.d/k8s.conf
+        content: |
+          overlay
+          br_netfilter
+
+    - name: Set required sysctl params for Kubernetes networking
+      ansible.builtin.sysctl:
+        name: "{{ item.key }}"
+        value: "{{ item.value }}"
+        sysctl_file: /etc/sysctl.d/k8s.conf
+        state: present
+        reload: yes
+      loop:
+        - { key: 'net.bridge.bridge-nf-call-iptables', value: '1' }
+        - { key: 'net.bridge.bridge-nf-call-ip6tables', value: '1' }
+        - { key: 'net.ipv4.ip_forward', value: '1' }
+
+    - name: Install prerequisite packages
+      ansible.builtin.apt:
+        name:
+          - apt-transport-https
+          - ca-certificates
+          - curl
+          - gnupg
+        state: present
+
+    - name: Install containerd (container runtime)
+      ansible.builtin.apt:
+        name: containerd.io
+        state: present
+
+    - name: Create default containerd configuration
+      ansible.builtin.file:
+        path: /etc/containerd
+        state: directory
+        mode: '0755'
+
+    - name: Generate containerd config and enable SystemdCgroup
+      ansible.builtin.shell: |
+        containerd config default | tee /etc/containerd/config.toml
+
+    - name: Enable SystemdCgroup
+      ansible.builtin.shell: |
+        sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+
+    - name: Ensure CRI plugin is enabled in containerd
+      ansible.builtin.lineinfile:
+        path: /etc/containerd/config.toml
+        regexp: '^\s*disabled_plugins = \["cri"\]'
+        line: '# disabled_plugins = ["cri"]'
+        state: present
+
+    - name: Restart and enable containerd service
+      ansible.builtin.systemd:
+        name: containerd
+        state: restarted
+        enabled: yes
+        daemon_reload: yes
+
+
+    - name: Download and add Google's APT signing key for Kubernetes
+      ansible.builtin.shell: "curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.29/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg"
+      args:
+        creates: /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+
+    - name: Add Kubernetes APT repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.26/deb/ /"
+        state: present
+        filename: kubernetes
+
+    - name: Install Kubernetes components (kubelet, kubeadm, kubectl)
+      ansible.builtin.apt:
+        name:
+          - kubelet==1.26.5-1.1
+          - kubeadm==1.26.5-1.1
+          - kubectl==1.26.5-1.1
+        state: present
+        update_cache: yes
+
+    - name: Hold Kubernetes components at their current version
+      ansible.builtin.dpkg_selections:
+        name: "{{ item }}"
+        selection: hold
+      loop:
+        - kubelet==1.26.5-1.1
+        - kubeadm==1.26.5-1.1
+        - kubectl==1.26.5-1.1
+    - name: Set crictl's runtime endpoint to containerd
+      ansible.builtin.shell: |
+        crictl config --set runtime-endpoint=unix:///run/containerd/containerd.sock --set image-endpoint=unix:///run/containerd/containerd.sock

--- a/ansible/playbooks/microk8_cluster.yaml
+++ b/ansible/playbooks/microk8_cluster.yaml
@@ -1,0 +1,70 @@
+---
+# Play 1: Install MicroK8s on all nodes
+- name: Install MicroK8s on Master and Worker Nodes
+  hosts: master, workers
+  become: yes
+  tasks:
+    - name: Ensure apt cache is updated
+      ansible.builtin.apt:
+        update_cache: yes
+      changed_when: false
+
+    - name: Install MicroK8s from snap
+      community.general.snap:
+        name: microk8s
+        classic: yes
+        channel: 1.28/stable # Use a specific stable channel for consistency
+
+    - name: Add current user to the 'microk8s' group for non-sudo access
+      ansible.builtin.user:
+        name: "{{ ansible_user }}"
+        groups: microk8s
+        append: yes
+
+    - name: Wait until MicroK8s is ready
+      ansible.builtin.command: /snap/bin/microk8s status --wait-ready
+      register: microk8s_status
+      until: microk8s_status.rc == 0
+      retries: 5
+      delay: 10
+      changed_when: false # This command does not change state
+
+# Play 2: Configure Master Node and Get Join Token
+- name: Configure Master Node
+  hosts: master
+  become: yes
+  tasks:
+    - name: Generate a join token for worker nodes
+      ansible.builtin.command: /snap/bin/microk8s add-node
+      register: join_command_result
+      # Mark as changed only if a new token was actually generated
+      changed_when: "'To join this cluster' in join_command_result.stdout"
+
+    - name: Extract the join command from the output
+      ansible.builtin.set_fact:
+        join_command: "{{ join_command_result.stdout_lines | select('match', 'microk8s join') | first }}"
+
+    - name: Enable essential addons (DNS, Dashboard, Storage)
+      ansible.builtin.command: "/snap/bin/microk8s enable {{ item }}"
+      loop:
+        - dns
+        - dashboard
+        - hostpath-storage
+      changed_when: false
+
+# Play 3: Join Worker Nodes to the Cluster
+- name: Join Worker Nodes
+  hosts: workers
+  become: yes
+  tasks:
+    - name: Check if the worker is already part of the cluster
+      ansible.builtin.command: "/snap/bin/microk8s kubectl get nodes {{ inventory_hostname }}"
+      delegate_to: "{{ groups['master'][0] }}"
+      become: yes
+      register: node_status
+      ignore_errors: true # The command fails if the node is not found, which is expected
+
+    - name: Join worker to the master node
+      ansible.builtin.shell: "{{ hostvars[groups['master'][0]]['join_command'] }}"
+      # Only run this task if the node is not already in the cluster
+      when: node_status.rc != 0

--- a/ansible/playbooks/test.yaml
+++ b/ansible/playbooks/test.yaml
@@ -1,0 +1,12 @@
+- name: Install Kubeflow
+  hosts: master
+  vars:
+    kubeflow_manifests_repo: "https://github.com/kubeflow/manifests.git"
+    kubeflow_manifests_tag: "v1.10.1" # You can change this to your desired tag
+  tasks:
+    - name: Read and modify pv-nfs.yaml
+      ansible.builtin.template:
+        src: "{{ playbook_dir }}/files/pv-nfs.yaml.j2"
+        dest: "{{ ansible_user_dir }}/pv-nfs-modified.yaml"
+      vars:
+        nfs_server_ip: "{{ ansible_default_ipv4['address'] }}"


### PR DESCRIPTION
This pull request introduces significant updates to the Ansible configuration for managing Kubernetes clusters and container runtime installation. It includes improvements to variable handling, new inventory files for host management, and comprehensive playbooks for setting up containerd and Kubernetes clusters. Below is a summary of the most important changes grouped by theme.

### Improvements to Variable Handling:
* Updated `rbp5_address` logic in `ansible/default-playbook-local.yaml` to use `startswith` for IP checks instead of `ipsubnet`. Added a fallback to `ip_addr` with a default value of `'0.0.0.0'` for better handling of undefined IPs.

### Host Inventory Management:
* Added new inventory file `ansible/inv-keti/0 - default.yml` to define hosts for NVIDIA and Raspberry Pi devices with corresponding IPs and users.
* Created `ansible/inv-keti/1 - k8s-vm.yml` to manage Kubernetes virtual machines, including master and worker nodes with specified credentials.
* Added `ansible/inv-keti/1 - k8s.yml` to define master and worker nodes for Kubernetes clusters running on physical devices.

### Container Runtime Setup:
* Introduced `ansible/playbooks/install_containerd.yaml`, a playbook for installing containerd.io from Docker's official repository. Includes steps for setting up Docker's APT repository, installing necessary packages, and verifying the installation.

### Kubernetes Cluster Configuration:
* Added `ansible/playbooks/k8s_cluster.yaml`, a comprehensive playbook for preparing nodes, initializing the master node, and joining worker nodes to the Kubernetes cluster. Includes tasks for disabling swap, configuring container runtime, installing Kubernetes components, and applying Calico CNI for networking.